### PR TITLE
real fix of crosshair cvar value

### DIFF
--- a/CSGOSimple/hooks.cpp
+++ b/CSGOSimple/hooks.cpp
@@ -83,8 +83,8 @@ namespace Hooks
 		mat_ambient_light_r->SetValue(g_Options.mat_ambient_light_r);
 		mat_ambient_light_g->SetValue(g_Options.mat_ambient_light_g);
 		mat_ambient_light_b->SetValue(g_Options.mat_ambient_light_b);
-		if (g_Options.esp_enabled)
-			crosshair_cvar->SetValue(!g_Options.esp_crosshair);
+		
+		crosshair_cvar->SetValue(!(g_Options.esp_enabled && g_Options.esp_crosshair));
 
 		DWORD colorwrite, srgbwrite;
 		pDevice->GetRenderState(D3DRS_COLORWRITEENABLE, &colorwrite);


### PR DESCRIPTION
Это фиксит следующее:
Когда ты включаешь прицел и ESP, то при выключении ESP - нарисованный прицел пропадет, а внутриигровой не появится