### PR TITLE
Math's Normalize3 Optimization

### DIFF
--- a/CSGOSimple/helpers/math.hpp
+++ b/CSGOSimple/helpers/math.hpp
@@ -26,7 +26,7 @@ namespace Math
 	template<class T>
 	void Normalize3(T& vec)
 	{
-		for (auto i = 0; i < 3; i++) {
+		for (auto i = 0; i < 2; i++) {
 			while (vec[i] < -180.0f) vec[i] += 360.0f;
 			while (vec[i] >  180.0f) vec[i] -= 360.0f;
 		}


### PR DESCRIPTION
I reduced the counter in the loop from 3 to 2. It is a simple optimization, but it helps avoid iterating through 2 different loops.
It can be done since we will set the roll (vec[2])  to 0.f anyways.