### PR TITLE
Update visuals.cpp

### DIFF
--- a/CSGOSimple/features/visuals.cpp
+++ b/CSGOSimple/features/visuals.cpp
@@ -165,6 +165,7 @@ void Visuals::Player::RenderWeaponName()
 	auto weapon = ctx.pl->m_hActiveWeapon().Get();
 
 	if (!weapon) return;
+	if (!weapon->GetCSWeaponData()) return;
 
 	auto text = weapon->GetCSWeaponData()->szWeaponName + 7;
 	auto sz = g_pDefaultFont->CalcTextSizeA(14.f, FLT_MAX, 0.0f, text);


### PR DESCRIPTION
Fix an annoying crash caused when using WeaponESP, as sometimes a weapon's data is null which will cause a crash any time WeaponESP is used with dying players.