### PR TITLE
Fixed m_iItemDefinitionIndex being read as int instead of short

### DIFF
--- a/CSGOSimple/valve_sdk/csgostructs.hpp
+++ b/CSGOSimple/valve_sdk/csgostructs.hpp
@@ -68,7 +68,7 @@ private:
 	using str_32 = char[32];
 public:
 	NETVAR(int32_t, m_bInitialized, "DT_BaseAttributableItem", "m_bInitialized");
-	NETVAR(int32_t, m_iItemDefinitionIndex, "DT_BaseAttributableItem", "m_iItemDefinitionIndex");
+	NETVAR(int16_t, m_iItemDefinitionIndex, "DT_BaseAttributableItem", "m_iItemDefinitionIndex");
 	NETVAR(int32_t, m_iEntityLevel, "DT_BaseAttributableItem", "m_iEntityLevel");
 	NETVAR(int32_t, m_iAccountID, "DT_BaseAttributableItem", "m_iAccountID");
 	NETVAR(int32_t, m_iItemIDLow, "DT_BaseAttributableItem", "m_iItemIDLow");


### PR DESCRIPTION
A very simple fix that without could lead to major issues down the road for anyone trying to experiment 